### PR TITLE
Fixed item tooltip

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
-mod_version=2.0
+mod_version=2.1
 modid=simply_trophies
 mc_version=1.15.2
-forge_version=31.1.0
+forge_version=31.2.37
 mapping=20200202

--- a/src/main/java/tfar/simpletrophies/common/config/TrophyConfig.java
+++ b/src/main/java/tfar/simpletrophies/common/config/TrophyConfig.java
@@ -23,6 +23,8 @@ public class TrophyConfig {
     public static ForgeConfigSpec.BooleanValue NO_TEISR;
     public static ForgeConfigSpec.BooleanValue NO_TESR;
     public static ForgeConfigSpec.BooleanValue TOOLTIP_CREDITS;
+    public static ForgeConfigSpec.BooleanValue SHOW_ITEMNAME;
+    public static ForgeConfigSpec.BooleanValue SHOW_ITEMTOOLTIP;
     public static ForgeConfigSpec.BooleanValue SHOW_EARNEDAT;
     public static ForgeConfigSpec.DoubleValue SCALE;
 
@@ -50,6 +52,12 @@ public class TrophyConfig {
       SHOW_EARNEDAT = builder
               .comment("Show the date and time you earned the trophy on the tooltip and on hover.")
               .define("show earnedat",true);
+      SHOW_ITEMNAME = builder
+              .comment("Show name of the displayed item.")
+              .define("show itemname", true);
+      SHOW_ITEMTOOLTIP = builder
+              .comment("Show tooltip of the displayed item.")
+              .define("show tooltip", false);
       SCALE = builder
               .comment("Scale of items on trophies")
               .defineInRange("scale",1.5,0,Double.MAX_VALUE);

--- a/src/main/java/tfar/simpletrophies/common/item/ItemSimpleTrophy.java
+++ b/src/main/java/tfar/simpletrophies/common/item/ItemSimpleTrophy.java
@@ -33,7 +33,7 @@ import java.awt.datatransfer.StringSelection;
 import java.util.ArrayList;
 import java.util.List;
 
-import static tfar.simpletrophies.common.config.TrophyConfig.ClientConfig.SHOW_EARNEDAT;
+import static tfar.simpletrophies.common.config.TrophyConfig.ClientConfig.*;
 
 public class ItemSimpleTrophy extends BlockItem {
 	public ItemSimpleTrophy(Block block, Properties properties) {
@@ -82,32 +82,36 @@ public class ItemSimpleTrophy extends BlockItem {
 		ItemStack displayedStack = TrophyHelpers.getDisplayedStack(stack);
 		if(!displayedStack.isEmpty()) {
 			//add the "Displayed" tooltip
-			tooltip.add(new TranslationTextComponent("simple_trophies.misc.tooltip.displaying",displayedStack.getDisplayName()).applyTextStyles(displayedStack.getRarity().color));
-			
-			//add additional debugging information
-			if(mistake.isAdvanced()) {
-				StringBuilder bob = new StringBuilder();
-				bob.append("   ");
-				bob.append(TextFormatting.DARK_GRAY);
-				bob.append(displayedStack.getItem().getRegistryName());
-				bob.append(" (#");
-				bob.append(Item.getIdFromItem(displayedStack.getItem()));
-				bob.append('/');
+			if(SHOW_ITEMNAME.get()) {
+				tooltip.add(new TranslationTextComponent("simple_trophies.misc.tooltip.displaying",displayedStack.getDisplayName()).applyTextStyles(displayedStack.getRarity().color));
+
+				//add additional debugging information
+				if(mistake.isAdvanced()) {
+					StringBuilder bob = new StringBuilder();
+					bob.append("   ");
+					bob.append(TextFormatting.DARK_GRAY);
+					bob.append(displayedStack.getItem().getRegistryName());
+					bob.append(" (#");
+					bob.append(Item.getIdFromItem(displayedStack.getItem()));
+					bob.append('/');
 //				bob.append(displayedStack.getItemDamage());
-				bob.append(')');
-				tooltip.add(new StringTextComponent(bob.toString()));
+					bob.append(')');
+					tooltip.add(new StringTextComponent(bob.toString()));
+				}
 			}
 			
 			//add the item itself's tooltip. Why not?
-			List<ITextComponent> displayedTooltip = new ArrayList<>();
-			displayedStack.getItem().addInformation(displayedStack, world, displayedTooltip, mistake);
-			displayedTooltip.forEach(s -> tooltip.add(new StringTextComponent("   " + s)));
+			if(SHOW_ITEMTOOLTIP.get()) {
+				List<ITextComponent> displayedTooltip = new ArrayList<>();
+				displayedStack.getItem().addInformation(displayedStack, world, displayedTooltip, mistake);
+				displayedTooltip.forEach(s -> tooltip.add(new StringTextComponent("   ").appendSibling(s)));
+			}
 		}
 
 		
 		long time = TrophyHelpers.getEarnTime(stack);
 		if(SHOW_EARNEDAT.get() && time != 0) {
-			tooltip.add(new TranslationTextComponent("simple_trophies.misc.earnedAt", DateHelpers.epochToString(time)));
+			tooltip.add(new TranslationTextComponent("simple_trophies.misc.earnedAt", DateHelpers.epochToString(time)).applyTextStyle(TextFormatting.GRAY));
 		}
 
 		super.addInformation(stack, world, tooltip, mistake);


### PR DESCRIPTION
I noticed an issue:
If you have an item with a tooltip that shows additional information while holding shift and create a trophy with it, the trophy tooltip becomes a weird mess of text components and translation keys.
![image](https://user-images.githubusercontent.com/19636565/94870617-45321a80-0448-11eb-823c-66060dc01ae5.png)

I fixed this issue (you have to use appendSibling() (or append() in 1.16) to concatenate TextComponents) and also added client config options to disable the item name/tooltip display in the trophy's tooltip.
![image](https://user-images.githubusercontent.com/19636565/94870921-10729300-0449-11eb-8dd4-1110dd2d0020.png)
![image](https://user-images.githubusercontent.com/19636565/94870852-e9b45c80-0448-11eb-807f-da331fa2ad49.png)
![image](https://user-images.githubusercontent.com/19636565/94870955-21230900-0449-11eb-8173-c8780aa16b9f.png)

Happy #Hacktoberfest !